### PR TITLE
Legg til kall i katalog for å lage aktiviteter og transmissions på dialoger

### DIFF
--- a/kataloger/dialogporten/aktivitet.bru
+++ b/kataloger/dialogporten/aktivitet.bru
@@ -1,0 +1,27 @@
+meta {
+  name: aktivitet
+  type: http
+  seq: 4
+}
+
+post {
+  url: https://platform.tt02.altinn.no/dialogporten/api/v1/serviceowner/dialogs/{{dialogId}}/activities
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "id": "019518dd-900d-74de-ab05-135ed6f0798e",
+    "type": "Information",
+    "performedBy": {
+      "actorType": "ServiceOwner"
+    },
+    "description": [
+      {
+        "value": "Innsendt inntektsmelding godkjent.",
+        "languageCode": "nb"
+      }
+    ]
+  }
+}

--- a/kataloger/dialogporten/collection.bru
+++ b/kataloger/dialogporten/collection.bru
@@ -1,3 +1,7 @@
+vars:pre-request {
+  dialogId: 0194f986-e8a3-71e3-9081-0502fc1a5c15
+}
+
 script:pre-request {
   const http = require('axios');
   let service = "sykepenger-im-lps-api"

--- a/kataloger/dialogporten/dialog ID.bru
+++ b/kataloger/dialogporten/dialog ID.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: https://platform.tt02.altinn.no/dialogporten/api/v1/serviceowner/dialogs/0194bc95-97b4-7240-961f-9663743d4518
+  url: https://platform.tt02.altinn.no/dialogporten/api/v1/serviceowner/dialogs/{{dialogId}}
   body: none
   auth: none
 }

--- a/kataloger/dialogporten/transmission.bru
+++ b/kataloger/dialogporten/transmission.bru
@@ -1,0 +1,41 @@
+meta {
+  name: transmission
+  type: http
+  seq: 5
+}
+
+post {
+  url: https://platform.tt02.altinn.no/dialogporten/api/v1/serviceowner/dialogs/{{dialogId}}/transmissions
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "id": "01951933-2973-7c64-8651-29fb9865b2e1",
+    "type": "Information",
+    "sender": {
+      "actorType": "ServiceOwner"
+    },
+    "content": {
+      "title": {
+        "value": [
+          {
+            "value": "Innsendt inntektsmelding godkjent",
+            "languageCode": "nb"
+          }
+        ],
+        "mediaType": "text/plain"
+      },
+      "summary": {
+        "value": [
+          {
+            "value": "Innsendt inntektsmelding godkjent",
+            "languageCode": "nb"
+          }
+        ],
+        "mediaType": "text/plain"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Vi vet ikke helt hvordan vi skal bruke aktiviteter og transmissions (også kjent som forsendelser) på dialoger ennå, men jeg legger det til i katalogen så de blir enkelt å teste. 